### PR TITLE
Fix condition to create a new db directory

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -43,10 +43,16 @@ impl Log {
         let path_str = path;
         let path = PathBuf::from(path);
 
-        if !path.exists() && !create || path.exists() && !path.is_dir() {
-            return Err(Error::InvalidPath(path_str.to_string()));
+        if create {
+            if path.exists() && !path.is_dir() {
+                return Err(Error::InvalidPath(path_str.to_string()));
+            } else if !path.exists() {
+                fs::create_dir(&path)?;
+            }
         } else {
-            fs::create_dir(&path)?;
+            if !path.exists() {
+                return Err(Error::InvalidPath(path_str.to_string()));
+            }
         }
 
         let lock_file = File::create(path.join(LOCK_FILE_NAME))?;

--- a/src/log.rs
+++ b/src/log.rs
@@ -50,7 +50,7 @@ impl Log {
                 fs::create_dir(&path)?;
             }
         } else {
-            if !path.exists() {
+            if !path.exists() || !path.is_dir() {
                 return Err(Error::InvalidPath(path_str.to_string()));
             }
         }


### PR DESCRIPTION
Current `create` condition has two problems.

- When `.create(false)` is set, cask always tries to create a new db directory.
- When `.create(true)` and directory already exists, cask fails to start due to file already exist error.

This patch fixes these conditions.